### PR TITLE
Add server.close()

### DIFF
--- a/index.js
+++ b/index.js
@@ -261,6 +261,11 @@ exports.createServer = function(proxy) {
 		server.bind(port || 53);
 		return that;
 	};
+	
+	that.close = function(callback) {
+		server.close(callback);
+		return that;
+	};
 
 	return that;
 };


### PR DESCRIPTION
This PR adds a `close([callback])` function to the server.
Use case: need to free port.
